### PR TITLE
Added chaining through enable disable methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,10 +52,14 @@ module.exports = function handler(element, opt) {
     
     emitter.enable = function enable() {
         funcs.forEach(listeners(element, true))
+
+        return emitter
     }
 
     emitter.disable = function dispose() { 
         funcs.forEach(listeners(element, false))
+
+        return emitter
     }
 
     //initially enabled


### PR DESCRIPTION
Currently if you do something like:

```
function getTouches() {
    return require('touches')
    .on( 'start', function() {} )
    .disable();
}
```

`undefined` would be returned. The  implementation should be consistent so if you do:

```
function getTouches() {
    return require('touches')
    .on( 'start', function() {} )
}
```

The same `emitter` is returned.
