### PR TITLE
Handle touchcancel

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var ROOT = { left: 0, top: 0 }
 module.exports = function handler(element, opt) {
     opt = opt||{}
     element = element || window
-    
+
     var emitter = new Emitter()
     emitter.target = opt.target || element
 
@@ -43,27 +43,27 @@ module.exports = function handler(element, opt) {
 
             //get 2D position
             var pos = offset(client, emitter.target)
-            
+
             //dispatch the normalized event to our emitter
             emitter.emit(name, ev, pos)
         }
         return { type: type, listener: fn }
     })
-    
+
     emitter.enable = function enable() {
         funcs.forEach(listeners(element, true))
 
         return emitter
     }
 
-    emitter.disable = function dispose() { 
+    emitter.disable = function dispose() {
         funcs.forEach(listeners(element, false))
 
         return emitter
     }
 
     //initially enabled
-    emitter.enable() 
+    emitter.enable()
     return emitter
 
     function getFilteredTouch(ev, type) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var Emitter = require('events/')
 
 var allEvents = [
-    'touchstart', 'touchmove', 'touchend',
+    'touchstart', 'touchmove', 'touchend', 'touchcancel',
     'mousedown', 'mousemove', 'mouseup'
 ]
 
@@ -69,8 +69,8 @@ module.exports = function handler(element, opt) {
     function getFilteredTouch(ev, type) {
         var client
 
-        //clear touch if it was lifted
-        if (touch && /^touchend/.test(type)) {
+        //clear touch if it was lifted or canceled
+        if (touch && /^touch(end|cancel)/.test(type)) {
             //allow end event to trigger on tracked touch
             client = getTouch(ev.changedTouches, touch.identifier||0)
             if (client)


### PR DESCRIPTION
In the current code, for filtered touches, if a touch is started and the the `touchcancel` event is fired by the browser (very easy to do by just opening the top and bottom menus in iOS), no `touchend` event will be fired (only tested on iOS 8). Since no `touchend` is fired, the filtered touch will not be cleared and the `touchstart` logic will not take place when the user touches again. This pull changes the code such that `touchcancel` acts functionally as a `touchend` event.
