### PR TITLE
Disable "passive" event listening.

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,8 +120,8 @@ function getTouch (touches, id) {
 
 function listeners (e, enabled) {
   return function (data) {
-    if (enabled) e.addEventListener(data.type, data.listener)
-    else e.removeEventListener(data.type, data.listener)
+    if (enabled) e.addEventListener(data.type, data.listener, { passive: false })
+    else e.removeEventListener(data.type, data.listener, { passive: false })
   }
 }
 


### PR DESCRIPTION
[Upcoming change in Chrome/Android](https://www.chromestatus.com/features/5093566007214080).

Not supplying the `passive` option will produce a warning message in Chrome's mobile emulation mode, and in the future will change the behaviour of document-level event listeners such that `e.preventDefault()` will no longer work.

This commit passes `{ passive: false }` into event listeners, ensuring that the current behaviour is maintained in newer versions of Android and Chrome.

Note that there are cases where `{ passive: true }` will [improve performance](https://medium.com/@devlucky/about-passive-event-listeners-224ff620e68c), and that you may want to expose this as an option in "touches"' public API: see also.

Thanks! :)