### PR TITLE
Fix: clear touch state when disabling

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@ module.exports = function handler (element, opt) {
   }
 
   emitter.disable = function dispose () {
+    touch = null
     funcs.forEach(listeners(element, false))
 
     return emitter


### PR DESCRIPTION
Previously, if you were to disable a touches instance while a touch was pressed down, and the touches instance had `filtered: true`, touch events would no longer be registered.

This was due to `touchend` and/or `touchcancel` not firing if the instance was disabled.

Thanks! :)